### PR TITLE
Add crate metadata and comprehensive rustdoc documentation

### DIFF
--- a/crates/pointslicer-cli/Cargo.toml
+++ b/crates/pointslicer-cli/Cargo.toml
@@ -2,6 +2,13 @@
 name = "pointslicer"
 version.workspace = true
 edition.workspace = true
+description = "CLI tool for extracting points from LAS/LAZ files using GeoPackage tile indices"
+repository = "https://github.com/stefan-kuepper/pointslicer"
+keywords = ["gis", "point-cloud", "las", "laz", "geopackage", "spatial", "lidar", "cli"]
+categories = ["science::gis", "filesystem", "parsing", "command-line-utilities"]
+readme = "README.md"
+license = "GPL-3.0"
+documentation = "https://docs.rs/pointslicer"
 
 [[bin]]
 name = "pointslicer"

--- a/crates/pointslicer-cli/src/cli/mod.rs
+++ b/crates/pointslicer-cli/src/cli/mod.rs
@@ -1,9 +1,9 @@
 pub mod commands;
 
 use commands::{Cli, Commands};
+use pointslicer_core::Result;
 use pointslicer_core::geometry::{BoundingBox, VerticalCylinder};
 use pointslicer_core::pipeline::ExtractionPipeline;
-use pointslicer_core::Result;
 
 /// Execute the CLI command
 pub fn execute(cli: Cli) -> Result<()> {

--- a/crates/pointslicer-core/Cargo.toml
+++ b/crates/pointslicer-core/Cargo.toml
@@ -2,6 +2,13 @@
 name = "pointslicer-core"
 version.workspace = true
 edition.workspace = true
+description = "Extract points from LAS/LAZ files using GeoPackage tile indices"
+repository = "https://github.com/stefan-kuepper/pointslicer"
+keywords = ["gis", "point-cloud", "las", "laz", "geopackage", "spatial", "lidar"]
+categories = ["science::gis", "filesystem", "parsing"]
+readme = "README.md"
+license = "GPL-3.0"
+documentation = "https://docs.rs/pointslicer-core"
 
 [dependencies]
 # LAS/LAZ I/O

--- a/crates/pointslicer-core/src/error.rs
+++ b/crates/pointslicer-core/src/error.rs
@@ -1,27 +1,79 @@
+//! Error types for the pointslicer library.
+//!
+//! This module defines the main error type [`TileIndexError`] and a convenience
+//! [`Result`] type alias used throughout the library.
+
 use thiserror::Error;
 
+/// The main error type for tile index operations.
+///
+/// This enum represents all possible errors that can occur during point cloud
+/// extraction operations, including GeoPackage I/O, LAS/LAZ file operations,
+/// and spatial query errors.
 #[derive(Error, Debug)]
 pub enum TileIndexError {
+    /// Failed to open a GeoPackage file.
+    ///
+    /// This error occurs when the GeoPackage file cannot be opened or is
+    /// not a valid GeoPackage database.
     #[error("Failed to open GeoPackage: {0}")]
     GeoPackageOpen(String),
 
+    /// Failed to query tiles from the GeoPackage.
+    ///
+    /// This error occurs when SQL queries against the tile index fail,
+    /// typically due to database schema issues or invalid SQL.
     #[error("Failed to query tiles: {0}")]
     TileQuery(String),
 
+    /// Invalid geometry found in the tile index.
+    ///
+    /// This error occurs when the geometry data in the GeoPackage cannot
+    /// be parsed or is in an unsupported format.
     #[error("Invalid geometry in tile index: {0}")]
     InvalidGeometry(String),
 
+    /// LAS/LAZ file I/O error.
+    ///
+    /// This error wraps errors from the `las` crate when reading or
+    /// writing point cloud files.
     #[error("LAS/LAZ file error: {0}")]
     PointCloudIO(#[from] las::Error),
 
+    /// No tiles found intersecting the extraction geometry.
+    ///
+    /// This error occurs when the spatial query returns no tiles that
+    /// intersect with the specified extraction geometry.
     #[error("No tiles found intersecting the extraction geometry")]
     NoTilesFound,
 
+    /// Output file creation error.
+    ///
+    /// This error occurs when the output LAS/LAZ file cannot be created
+    /// or written to.
     #[error("Output file error: {0}")]
     OutputError(String),
 
+    /// General I/O error.
+    ///
+    /// This error wraps standard I/O errors that occur during file operations.
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 }
 
+/// Convenience result type alias for the library.
+///
+/// This type alias is used throughout the library to simplify error handling.
+/// It represents operations that can fail with a [`TileIndexError`].
+///
+/// # Example
+///
+/// ```no_run
+/// use pointslicer_core::Result;
+///
+/// fn process_tiles() -> Result<()> {
+///     // Operations that can fail...
+///     Ok(())
+/// }
+/// ```
 pub type Result<T> = std::result::Result<T, TileIndexError>;

--- a/crates/pointslicer-core/src/geometry/bbox.rs
+++ b/crates/pointslicer-core/src/geometry/bbox.rs
@@ -1,14 +1,49 @@
 use super::traits::ExtractGeometry;
 use geo::{Rect, coord};
 
-/// A 2D or 3D bounding box for point extraction
+/// A 2D or 3D axis-aligned bounding box for point extraction.
+///
+/// This struct represents a rectangular region in 2D or 3D space that can be
+/// used to filter points. It supports both 2D (X,Y only) and 3D (X,Y,Z)
+/// extraction.
+///
+/// # Examples
+///
+/// ```
+/// use pointslicer_core::geometry::{BoundingBox, ExtractGeometry};
+///
+/// // Create a 2D bounding box
+/// let bbox_2d = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+///
+/// // Create a 3D bounding box with Z constraints
+/// let bbox_3d = BoundingBox::new_3d(10000.0, 20000.0, 30000.0, 40000.0, 0.0, 100.0);
+///
+/// // Check if a point is inside
+/// assert!(bbox_2d.contains_xy(15000.0, 35000.0));
+/// assert!(bbox_3d.contains_xyz(15000.0, 35000.0, 50.0));
+/// ```
 #[derive(Debug, Clone)]
 pub struct BoundingBox {
+    /// Minimum X coordinate of the bounding box.
     pub min_x: f64,
+
+    /// Maximum X coordinate of the bounding box.
     pub max_x: f64,
+
+    /// Minimum Y coordinate of the bounding box.
     pub min_y: f64,
+
+    /// Maximum Y coordinate of the bounding box.
     pub max_y: f64,
+
+    /// Optional minimum Z coordinate for 3D extraction.
+    ///
+    /// If `None`, no lower Z constraint is applied.
     pub min_z: Option<f64>,
+
+    /// Optional maximum Z coordinate for 3D extraction.
+    ///
+    /// If `None`, no upper Z constraint is applied.
     pub max_z: Option<f64>,
 }
 

--- a/crates/pointslicer-core/src/geometry/cylinder.rs
+++ b/crates/pointslicer-core/src/geometry/cylinder.rs
@@ -1,11 +1,37 @@
 use super::traits::ExtractGeometry;
 use geo::{Rect, coord};
 
-/// A vertical cylinder defined by center X,Y coordinates and radius
+/// A vertical cylinder defined by center coordinates and radius.
+///
+/// This struct represents a vertical (Z-aligned) cylinder that can be used
+/// to extract points within a circular region. The cylinder extends infinitely
+/// in the Z direction.
+///
+/// # Examples
+///
+/// ```
+/// use pointslicer_core::geometry::{VerticalCylinder, ExtractGeometry};
+///
+/// // Create a cylinder from diameter
+/// let cylinder = VerticalCylinder::from_diameter(12345.0, 67890.0, 12.0);
+///
+/// // Create a cylinder from radius
+/// let cylinder2 = VerticalCylinder::from_radius(12345.0, 67890.0, 6.0);
+///
+/// // Check if points are inside
+/// assert!(cylinder.contains_xy(12345.0, 67890.0)); // Center point
+/// assert!(cylinder.contains_xy(12351.0, 67890.0)); // 6 units right
+/// assert!(!cylinder.contains_xy(12357.0, 67890.0)); // 12 units right (outside)
+/// ```
 #[derive(Debug, Clone)]
 pub struct VerticalCylinder {
+    /// X coordinate of the cylinder center.
     pub center_x: f64,
+
+    /// Y coordinate of the cylinder center.
     pub center_y: f64,
+
+    /// Radius of the cylinder.
     pub radius: f64,
 }
 

--- a/crates/pointslicer-core/src/geometry/mod.rs
+++ b/crates/pointslicer-core/src/geometry/mod.rs
@@ -1,7 +1,108 @@
+//! Geometry system for spatial point extraction.
+//!
+//! This module provides a trait-based system for defining extraction geometries
+//! that can be used to filter points from LAS/LAZ files. The core abstraction
+//! is the [`ExtractGeometry`] trait, which defines the interface for any
+//! geometry that can extract points.
+//!
+//! ## Available Geometries
+//!
+//! - [`BoundingBox`]: A 2D or 3D axis-aligned bounding box
+//! - [`VerticalCylinder`]: A vertical cylinder defined by center coordinates and radius
+//!
+//! ## Adding Custom Geometries
+//!
+//! To add a new geometry type, implement the [`ExtractGeometry`] trait:
+//!
+//! ```no_run
+//! use pointslicer_core::geometry::ExtractGeometry;
+//! use geo::{Rect, coord};
+//!
+//! struct MyGeometry {
+//!     center_x: f64,
+//!     center_y: f64,
+//!     radius: f64,
+//! }
+//!
+//! impl ExtractGeometry for MyGeometry {
+//!     fn bounding_box(&self) -> Rect<f64> {
+//!         // Return the bounding rectangle of your geometry
+//!         Rect::new(
+//!             coord! { x: self.center_x - self.radius, y: self.center_y - self.radius },
+//!             coord! { x: self.center_x + self.radius, y: self.center_y + self.radius },
+//!         )
+//!     }
+//!     
+//!     fn contains_xy(&self, x: f64, y: f64) -> bool {
+//!         // Implement point-in-geometry test
+//!         let dx = x - self.center_x;
+//!         let dy = y - self.center_y;
+//!         dx * dx + dy * dy <= self.radius * self.radius
+//!     }
+//!     
+//!     fn contains_xyz(&self, x: f64, y: f64, _z: f64) -> bool {
+//!         self.contains_xy(x, y)
+//!     }
+//!     
+//!     fn intersects_rect(&self, rect: &Rect<f64>) -> bool {
+//!         // Implement rectangle intersection test
+//!         true // Simplified example
+//!     }
+//! }
+//! ```
+//!
+//! ## Usage Example
+//!
+//! ```no_run
+//! use pointslicer_core::geometry::{BoundingBox, VerticalCylinder, ExtractGeometry};
+//!
+//! // Create a 2D bounding box
+//! let bbox = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+//!
+//! // Create a vertical cylinder from diameter
+//! let cylinder = VerticalCylinder::from_diameter(12345.0, 67890.0, 12.0);
+//!
+//! // Check if points are inside the geometries
+//! assert!(bbox.contains_xy(15000.0, 35000.0));
+//! assert!(cylinder.contains_xy(12345.0, 67890.0));
+//! ```
+
 pub mod bbox;
 pub mod cylinder;
 pub mod traits;
 
+/// A 2D or 3D axis-aligned bounding box for point extraction.
+///
+/// This struct represents a rectangular region in 2D or 3D space that can be
+/// used to filter points. It supports both 2D (X,Y only) and 3D (X,Y,Z)
+/// extraction.
+///
+/// # Fields
+///
+/// - `min_x`: Minimum X coordinate
+/// - `max_x`: Maximum X coordinate  
+/// - `min_y`: Minimum Y coordinate
+/// - `max_y`: Maximum Y coordinate
+/// - `min_z`: Optional minimum Z coordinate (for 3D extraction)
+/// - `max_z`: Optional maximum Z coordinate (for 3D extraction)
 pub use bbox::BoundingBox;
+
+/// A vertical cylinder defined by center coordinates and radius.
+///
+/// This struct represents a vertical (Z-aligned) cylinder that can be used
+/// to extract points within a circular region. The cylinder extends infinitely
+/// in the Z direction.
+///
+/// # Fields
+///
+/// - `center_x`: X coordinate of the cylinder center
+/// - `center_y`: Y coordinate of the cylinder center
+/// - `radius`: Radius of the cylinder
 pub use cylinder::VerticalCylinder;
+
+/// The core trait for extraction geometries.
+///
+/// This trait defines the interface that all extraction geometries must
+/// implement. It provides methods for spatial queries that are used by
+/// the extraction pipeline to filter points.
 pub use traits::ExtractGeometry;

--- a/crates/pointslicer-core/src/geometry/traits.rs
+++ b/crates/pointslicer-core/src/geometry/traits.rs
@@ -1,16 +1,112 @@
 use geo::Rect;
 
-/// Trait for geometries that can be used to extract points from tiles
+/// Trait for geometries that can be used to extract points from tiles.
+///
+/// This trait defines the interface that all extraction geometries must implement.
+/// It provides methods for spatial queries that are used by the extraction
+/// pipeline to filter points efficiently.
+///
+/// # Requirements
+///
+/// Implementations must be `Send + Sync` to support parallel processing
+/// with Rayon.
+///
+/// # Examples
+///
+/// ```
+/// use pointslicer_core::geometry::ExtractGeometry;
+/// use geo::{Rect, coord};
+///
+/// struct MyGeometry {
+///     center_x: f64,
+///     center_y: f64,
+///     radius: f64,
+/// }
+///
+/// impl ExtractGeometry for MyGeometry {
+///     fn bounding_box(&self) -> Rect<f64> {
+///         Rect::new(
+///             coord! { x: self.center_x - self.radius, y: self.center_y - self.radius },
+///             coord! { x: self.center_x + self.radius, y: self.center_y + self.radius },
+///         )
+///     }
+///     
+///     fn contains_xy(&self, x: f64, y: f64) -> bool {
+///         let dx = x - self.center_x;
+///         let dy = y - self.center_y;
+///         dx * dx + dy * dy <= self.radius * self.radius
+///     }
+///     
+///     fn contains_xyz(&self, x: f64, y: f64, _z: f64) -> bool {
+///         self.contains_xy(x, y)
+///     }
+///     
+///     fn intersects_rect(&self, rect: &Rect<f64>) -> bool {
+///         // Find the closest point on the rectangle to the circle's center
+///         let closest_x = self.center_x.clamp(rect.min().x, rect.max().x);
+///         let closest_y = self.center_y.clamp(rect.min().y, rect.max().y);
+///         
+///         // Check if this closest point is within the circle
+///         self.contains_xy(closest_x, closest_y)
+///     }
+/// }
+/// ```
 pub trait ExtractGeometry: Send + Sync {
-    /// Get the 2D bounding box of this geometry (for spatial indexing)
+    /// Get the 2D bounding box of this geometry.
+    ///
+    /// This method returns the axis-aligned bounding rectangle that completely
+    /// contains the geometry. It is used for spatial indexing to quickly
+    /// identify which tiles might intersect with the geometry.
+    ///
+    /// # Returns
+    ///
+    /// A [`Rect<f64>`] representing the geometry's bounding box.
     fn bounding_box(&self) -> Rect<f64>;
 
-    /// Check if a 2D point (x, y) is within this geometry
+    /// Check if a 2D point (x, y) is within this geometry.
+    ///
+    /// This method tests whether a point with the given X and Y coordinates
+    /// lies inside the geometry, ignoring the Z coordinate.
+    ///
+    /// # Parameters
+    ///
+    /// - `x`: X coordinate of the point
+    /// - `y`: Y coordinate of the point
+    ///
+    /// # Returns
+    ///
+    /// `true` if the point is inside the geometry, `false` otherwise.
     fn contains_xy(&self, x: f64, y: f64) -> bool;
 
-    /// Check if a 3D point (x, y, z) is within this geometry
+    /// Check if a 3D point (x, y, z) is within this geometry.
+    ///
+    /// This method tests whether a point with the given X, Y, and Z coordinates
+    /// lies inside the geometry. For 2D geometries, this typically ignores
+    /// the Z coordinate.
+    ///
+    /// # Parameters
+    ///
+    /// - `x`: X coordinate of the point
+    /// - `y`: Y coordinate of the point
+    /// - `z`: Z coordinate of the point
+    ///
+    /// # Returns
+    ///
+    /// `true` if the point is inside the geometry, `false` otherwise.
     fn contains_xyz(&self, x: f64, y: f64, z: f64) -> bool;
 
-    /// Check if this geometry intersects with a rectangle (tile bounds)
+    /// Check if this geometry intersects with a rectangle (tile bounds).
+    ///
+    /// This method tests whether the geometry intersects with the given
+    /// rectangle. It is used to determine which tiles need to be processed
+    /// for point extraction.
+    ///
+    /// # Parameters
+    ///
+    /// - `rect`: The rectangle to test for intersection
+    ///
+    /// # Returns
+    ///
+    /// `true` if the geometry intersects the rectangle, `false` otherwise.
     fn intersects_rect(&self, rect: &Rect<f64>) -> bool;
 }

--- a/crates/pointslicer-core/src/index/mod.rs
+++ b/crates/pointslicer-core/src/index/mod.rs
@@ -1,5 +1,57 @@
+//! GeoPackage tile index reading and spatial filtering.
+//!
+//! This module provides functionality for reading GeoPackage tile indices
+//! created by `pdal tindex` and performing spatial queries to find tiles
+//! that intersect with extraction geometries.
+//!
+//! ## Key Components
+//!
+//! - [`TileIndexReader`]: Main interface for reading GeoPackage tile indices
+//! - [`TileInfo`]: Information about a single tile (file path and bounds)
+//! - [`TileMetadata`]: Metadata about a tile's spatial extent
+//!
+//! ## Usage Example
+//!
+//! ```no_run
+//! use pointslicer_core::index::TileIndexReader;
+//! use pointslicer_core::geometry::BoundingBox;
+//!
+//! // Open a GeoPackage tile index
+//! let reader = TileIndexReader::open("tiles.gpkg")?;
+//!
+//! // Create an extraction geometry
+//! let bbox = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+//!
+//! // Find tiles that intersect with the geometry
+//! let tiles = reader.read_tiles(None, &bbox)?;
+//!
+//! println!("Found {} intersecting tiles", tiles.len());
+//! # Ok::<(), pointslicer_core::TileIndexError>(())
+//! ```
+//!
+//! ## GeoPackage Format Support
+//!
+//! The module supports GeoPackage tile indices created by PDAL's `tindex` command,
+//! which typically contain:
+//! - A `location` column with file paths to LAS/LAZ tiles
+//! - A geometry column with tile bounds in GeoPackage Binary format
+//! - Metadata in `gpkg_contents` and `gpkg_geometry_columns` tables
+
 pub mod reader;
 pub mod tile;
 
+/// Reader for GeoPackage tile index files.
+///
+/// This struct provides methods to open GeoPackage files and query tiles
+/// that intersect with extraction geometries.
 pub use reader::TileIndexReader;
-pub use tile::{TileInfo, TileMetadata};
+
+/// Information about a single tile in the index.
+///
+/// Contains the file path to the LAS/LAZ tile and its spatial bounds.
+pub use tile::TileInfo;
+
+/// Metadata about a tile's spatial extent.
+///
+/// Contains the minimum and maximum coordinates of a tile's bounding box.
+pub use tile::TileMetadata;

--- a/crates/pointslicer-core/src/index/reader.rs
+++ b/crates/pointslicer-core/src/index/reader.rs
@@ -5,7 +5,34 @@ use geo::{Rect, coord};
 use rusqlite::Connection;
 use std::path::Path;
 
-/// Reader for GeoPackage tile index files
+/// Reader for GeoPackage tile index files.
+///
+/// This struct provides methods to open GeoPackage files created by `pdal tindex`
+/// and query tiles that intersect with extraction geometries.
+///
+/// # Examples
+///
+/// ```no_run
+/// use pointslicer_core::index::TileIndexReader;
+/// use pointslicer_core::geometry::BoundingBox;
+///
+/// # fn main() -> Result<(), pointslicer_core::TileIndexError> {
+/// // Open a GeoPackage tile index
+/// let reader = TileIndexReader::open("tiles.gpkg")?;
+///
+/// // List all feature tables
+/// let tables = reader.list_tables()?;
+/// println!("Available tables: {:?}", tables);
+///
+/// // Create an extraction geometry
+/// let bbox = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+///
+/// // Find intersecting tiles (uses first table if None)
+/// let tiles = reader.read_tiles(None, &bbox)?;
+/// println!("Found {} intersecting tiles", tiles.len());
+/// # Ok(())
+/// # }
+/// ```
 pub struct TileIndexReader {
     conn: Connection,
 }

--- a/crates/pointslicer-core/src/index/tile.rs
+++ b/crates/pointslicer-core/src/index/tile.rs
@@ -1,26 +1,43 @@
 use geo::Rect;
 use std::path::PathBuf;
 
-/// Information about a tile from the GeoPackage index
+/// Information about a tile from the GeoPackage index.
+///
+/// This struct contains the file path to a LAS/LAZ tile and its spatial
+/// bounds as extracted from the GeoPackage geometry.
+///
+/// # Fields
+///
+/// - `file_path`: Path to the LAS/LAZ file
+/// - `bounds`: 2D bounding box of the tile (from GeoPackage geometry)
+/// - `metadata`: Optional metadata about the tile
 #[derive(Debug, Clone)]
 pub struct TileInfo {
-    /// Path to the LAS/LAZ file
+    /// Path to the LAS/LAZ file.
     pub file_path: PathBuf,
 
-    /// 2D bounding box of the tile (from GeoPackage geometry)
+    /// 2D bounding box of the tile (from GeoPackage geometry).
     pub bounds: Rect<f64>,
 
-    /// Optional metadata
+    /// Optional metadata about the tile.
     pub metadata: Option<TileMetadata>,
 }
 
-/// Optional metadata for a tile
+/// Optional metadata for a tile.
+///
+/// This struct contains additional information about a tile that may be
+/// available in some GeoPackage indices.
+///
+/// # Fields
+///
+/// - `point_count`: Number of points in this tile (if available)
+/// - `srs`: Spatial reference system (if available)
 #[derive(Debug, Clone)]
 pub struct TileMetadata {
-    /// Number of points in this tile (if available)
+    /// Number of points in this tile (if available).
     pub point_count: Option<u64>,
 
-    /// Spatial reference system (if available)
+    /// Spatial reference system (if available).
     pub srs: Option<String>,
 }
 

--- a/crates/pointslicer-core/src/lib.rs
+++ b/crates/pointslicer-core/src/lib.rs
@@ -1,7 +1,95 @@
+//! # pointslicer-core
+//!
+//! A library for extracting points from LAS/LAZ files using GeoPackage tile indices.
+//!
+//! This library provides a trait-based architecture for spatial extraction of point cloud data.
+//! It reads tile indices created by `pdal tindex` and efficiently filters points using
+//! parallel processing with Rayon.
+//!
+//! ## Key Features
+//!
+//! - **Trait-based geometry system**: Implement the `ExtractGeometry` trait to add custom
+//!   extraction geometries
+//! - **Parallel processing**: Uses Rayon for efficient tile processing
+//! - **GeoPackage support**: Reads tile indices created by PDAL's `tindex` command
+//! - **LAS/LAZ I/O**: Supports both compressed and uncompressed point cloud formats
+//! - **Point format preservation**: Maintains original point format when writing output
+//!
+//! ## Basic Usage
+//!
+//! ```no_run
+//! use pointslicer_core::geometry::{BoundingBox, ExtractGeometry};
+//! use pointslicer_core::pipeline::ExtractionPipeline;
+//!
+//! // Create a bounding box geometry
+//! let bbox = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+//!
+//! // Create and run the extraction pipeline
+//! let pipeline = ExtractionPipeline::new("tiles.gpkg", "output.laz", false);
+//! let stats = pipeline.execute(&bbox).expect("Extraction failed");
+//!
+//! println!("Extracted {} points from {} tiles", stats.points_written, stats.tiles_processed);
+//! ```
+//!
+//! ## Architecture
+//!
+//! The library is organized into several modules:
+//!
+//! - [`error`]: Error types and result aliases
+//! - [`geometry`]: Trait-based geometry system for spatial queries
+//! - [`index`]: GeoPackage tile index reading and spatial filtering
+//! - [`pipeline`]: Orchestration of the extraction workflow
+//! - [`pointcloud`]: LAS/LAZ file I/O and point filtering
+//!
+//! ## Adding Custom Geometries
+//!
+//! To add a new extraction geometry, implement the [`ExtractGeometry`] trait:
+//!
+//! ```no_run
+//! use pointslicer_core::geometry::ExtractGeometry;
+//! use geo::{Rect, coord};
+//!
+//! struct MyGeometry {
+//!     center_x: f64,
+//!     center_y: f64,
+//!     radius: f64,
+//! }
+//!
+//! impl ExtractGeometry for MyGeometry {
+//!     fn bounding_box(&self) -> Rect<f64> {
+//!         // Return the bounding rectangle of your geometry
+//!         Rect::new(
+//!             coord! { x: self.center_x - self.radius, y: self.center_y - self.radius },
+//!             coord! { x: self.center_x + self.radius, y: self.center_y + self.radius },
+//!         )
+//!     }
+//!     
+//!     fn contains_xy(&self, x: f64, y: f64) -> bool {
+//!         // Implement point-in-geometry test
+//!         let dx = x - self.center_x;
+//!         let dy = y - self.center_y;
+//!         dx * dx + dy * dy <= self.radius * self.radius
+//!     }
+//!     
+//!     fn contains_xyz(&self, x: f64, y: f64, _z: f64) -> bool {
+//!         self.contains_xy(x, y)
+//!     }
+//!     
+//!     fn intersects_rect(&self, rect: &Rect<f64>) -> bool {
+//!         // Implement rectangle intersection test
+//!         true // Simplified example
+//!     }
+//! }
+//! ```
+
 pub mod error;
 pub mod geometry;
 pub mod index;
 pub mod pipeline;
 pub mod pointcloud;
 
-pub use error::{Result, TileIndexError};
+/// Re-export of the library's result type for convenience.
+pub use error::Result;
+
+/// Re-export of the main error type for tile index operations.
+pub use error::TileIndexError;

--- a/crates/pointslicer-core/src/pipeline/executor.rs
+++ b/crates/pointslicer-core/src/pipeline/executor.rs
@@ -7,19 +7,51 @@ use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
-/// Statistics from an extraction operation
+/// Statistics collected during an extraction operation.
+///
+/// This struct contains metrics about the extraction process including
+/// tile counts, point counts, and timing information.
+///
+/// # Fields
+///
+/// - `tiles_processed`: Number of tiles that were successfully processed
+/// - `points_read`: Total number of points read from all tiles
+/// - `points_written`: Number of points that passed the geometry filter
+/// - `elapsed_time`: Total time taken for the extraction
 #[derive(Debug, Clone)]
 pub struct ExtractionStats {
+    /// Number of tiles that were successfully processed.
     pub tiles_processed: usize,
+
+    /// Total number of points read from all tiles.
     pub points_read: u64,
+
+    /// Number of points that passed the geometry filter.
     pub points_written: u64,
+
+    /// Total time taken for the extraction.
     pub elapsed_time: Duration,
 }
 
-/// Pipeline for extracting points from a tile index
+/// Main pipeline for orchestrating point cloud extraction.
+///
+/// This struct manages the entire extraction workflow from reading tile indices
+/// to writing output files. It uses parallel processing with Rayon for
+/// efficient tile processing.
+///
+/// # Fields
+///
+/// - `index_path`: Path to the GeoPackage tile index file
+/// - `output_path`: Path where the extracted points will be written
+/// - `verbose`: Whether to log detailed progress information
 pub struct ExtractionPipeline {
+    /// Path to the GeoPackage tile index file.
     pub index_path: PathBuf,
+
+    /// Path where the extracted points will be written.
     pub output_path: PathBuf,
+
+    /// Whether to log detailed progress information.
     pub verbose: bool,
 }
 

--- a/crates/pointslicer-core/src/pipeline/mod.rs
+++ b/crates/pointslicer-core/src/pipeline/mod.rs
@@ -1,3 +1,51 @@
+//! Pipeline orchestration for point cloud extraction.
+//!
+//! This module provides the high-level pipeline that orchestrates the
+//! extraction workflow, including reading tile indices, processing tiles
+//! in parallel, filtering points, and writing output files.
+//!
+//! ## Key Components
+//!
+//! - [`ExtractionPipeline`]: Main pipeline struct that orchestrates the extraction process
+//! - [`ExtractionStats`]: Statistics collected during extraction
+//!
+//! ## Usage Example
+//!
+//! ```no_run
+//! use pointslicer_core::pipeline::ExtractionPipeline;
+//! use pointslicer_core::geometry::BoundingBox;
+//!
+//! # fn main() -> Result<(), pointslicer_core::TileIndexError> {
+//! // Create an extraction geometry
+//! let bbox = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+//!
+//! // Create and run the pipeline
+//! let pipeline = ExtractionPipeline::new("tiles.gpkg", "output.laz", false);
+//! let stats = pipeline.execute(&bbox)?;
+//!
+//! println!("Extracted {} points from {} tiles in {:?}",
+//!     stats.points_written, stats.tiles_processed, stats.elapsed_time);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Pipeline Flow
+//!
+//! 1. **Index Reading**: Opens GeoPackage, queries tiles intersecting the geometry
+//! 2. **Parallel Processing**: Uses Rayon to process tiles in parallel
+//! 3. **Point Filtering**: Filters points using geometry's `contains_xyz()` method
+//! 4. **Output Writing**: Writes filtered points to LAS/LAZ, preserving point format
+
 pub mod executor;
 
-pub use executor::{ExtractionPipeline, ExtractionStats};
+/// Main pipeline for orchestrating point cloud extraction.
+///
+/// This struct manages the entire extraction workflow from reading tile indices
+/// to writing output files.
+pub use executor::ExtractionPipeline;
+
+/// Statistics collected during an extraction operation.
+///
+/// Contains metrics about the extraction process including tile counts,
+/// point counts, and timing information.
+pub use executor::ExtractionStats;

--- a/crates/pointslicer-core/src/pointcloud/filter.rs
+++ b/crates/pointslicer-core/src/pointcloud/filter.rs
@@ -1,7 +1,44 @@
 use crate::geometry::ExtractGeometry;
 use las::Point;
 
-/// Filter points based on an extraction geometry
+/// Filter points based on an extraction geometry.
+///
+/// This function takes a slice of points and returns only those points
+/// that are inside the specified extraction geometry.
+///
+/// # Parameters
+///
+/// - `points`: Slice of points to filter
+/// - `geometry`: Extraction geometry to test points against
+///
+/// # Returns
+///
+/// A vector containing only the points that are inside the geometry.
+///
+/// # Examples
+///
+/// ```
+/// use pointslicer_core::pointcloud::filter_points;
+/// use pointslicer_core::geometry::BoundingBox;
+/// use las::Point;
+///
+/// let bbox = BoundingBox::new_2d(0.0, 10.0, 0.0, 10.0);
+///
+/// let mut point1 = Point::default();
+/// point1.x = 5.0;
+/// point1.y = 5.0;
+/// point1.z = 0.0;
+///
+/// let mut point2 = Point::default();
+/// point2.x = 15.0;
+/// point2.y = 15.0;
+/// point2.z = 0.0;
+///
+/// let points = vec![point1, point2];
+/// let filtered = filter_points(&points, &bbox);
+///
+/// assert_eq!(filtered.len(), 1);
+/// ```
 pub fn filter_points<G: ExtractGeometry>(points: &[Point], geometry: &G) -> Vec<Point> {
     points
         .iter()
@@ -10,7 +47,38 @@ pub fn filter_points<G: ExtractGeometry>(points: &[Point], geometry: &G) -> Vec<
         .collect()
 }
 
-/// Filter points from an iterator based on an extraction geometry
+/// Filter points from an iterator based on an extraction geometry.
+///
+/// This function takes an iterator of points and returns only those points
+/// that are inside the specified extraction geometry. This is more memory
+/// efficient than `filter_points()` for large datasets.
+///
+/// # Parameters
+///
+/// - `points`: Iterator of points to filter
+/// - `geometry`: Extraction geometry to test points against
+///
+/// # Returns
+///
+/// A vector containing only the points that are inside the geometry.
+///
+/// # Examples
+///
+/// ```
+/// use pointslicer_core::pointcloud::filter_points_iter;
+/// use pointslicer_core::geometry::BoundingBox;
+/// use las::Point;
+///
+/// let bbox = BoundingBox::new_2d(0.0, 10.0, 0.0, 10.0);
+///
+/// let points = vec![
+///     Point { x: 5.0, y: 5.0, z: 0.0, ..Default::default() },
+///     Point { x: 15.0, y: 15.0, z: 0.0, ..Default::default() },
+/// ];
+///
+/// let filtered = filter_points_iter(points.into_iter(), &bbox);
+/// assert_eq!(filtered.len(), 1);
+/// ```
 pub fn filter_points_iter<G: ExtractGeometry, I>(points: I, geometry: &G) -> Vec<Point>
 where
     I: Iterator<Item = Point>,

--- a/crates/pointslicer-core/src/pointcloud/mod.rs
+++ b/crates/pointslicer-core/src/pointcloud/mod.rs
@@ -1,7 +1,53 @@
+//! LAS/LAZ point cloud I/O and filtering.
+//!
+//! This module provides functionality for reading and writing LAS/LAZ files,
+//! as well as filtering points based on extraction geometries.
+//!
+//! ## Key Components
+//!
+//! - [`PointCloudReader`]: Wrapper for reading LAS/LAZ files
+//! - [`PointCloudWriter`]: Wrapper for writing LAS/LAZ files with format preservation
+//! - [`filter_points()`]: Function for filtering points using extraction geometries
+//! - [`filter_points_iter()`]: Iterator-based filtering for memory efficiency
+//!
+//! ## Usage Example
+//!
+//! ```no_run
+//! use pointslicer_core::pointcloud::{PointCloudReader, PointCloudWriter, filter_points};
+//! use pointslicer_core::geometry::BoundingBox;
+//!
+//! # fn main() -> Result<(), pointslicer_core::TileIndexError> {
+//! // Read points from a LAS/LAZ file
+//! let mut reader = PointCloudReader::open("input.laz")?;
+//! let points = reader.points()?;
+//!
+//! // Create an extraction geometry
+//! let bbox = BoundingBox::new_2d(10000.0, 20000.0, 30000.0, 40000.0);
+//!
+//! // Filter points
+//! let filtered = filter_points(&points, &bbox);
+//!
+//! // Write filtered points to a new file
+//! let mut writer = PointCloudWriter::create("output.laz", reader.header().clone())?;
+//! writer.write_points(&filtered)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Point Format Preservation
+//!
+//! The [`PointCloudWriter`] preserves the point format from the source file
+//! when creating output files, ensuring compatibility with downstream tools.
+
 pub mod filter;
 pub mod reader;
 pub mod writer;
 
+/// Functions for filtering points using extraction geometries.
 pub use filter::{filter_points, filter_points_iter};
+
+/// Wrapper for reading LAS/LAZ files.
 pub use reader::PointCloudReader;
+
+/// Wrapper for writing LAS/LAZ files with format preservation.
 pub use writer::PointCloudWriter;

--- a/crates/pointslicer-core/src/pointcloud/reader.rs
+++ b/crates/pointslicer-core/src/pointcloud/reader.rs
@@ -2,7 +2,31 @@ use crate::error::Result;
 use las::{Point, Read};
 use std::path::Path;
 
-/// Wrapper for reading LAS/LAZ files
+/// Wrapper for reading LAS/LAZ files.
+///
+/// This struct provides a convenient interface for reading point cloud data
+/// from LAS or LAZ files, with automatic decompression for LAZ files.
+///
+/// # Examples
+///
+/// ```no_run
+/// use pointslicer_core::pointcloud::PointCloudReader;
+///
+/// # fn main() -> Result<(), pointslicer_core::TileIndexError> {
+/// // Open a LAS/LAZ file
+/// let mut reader = PointCloudReader::open("input.laz")?;
+///
+/// // Get file header information
+/// let header = reader.header();
+/// println!("Point format: {:?}", header.point_format());
+/// println!("Number of points: {}", header.number_of_points());
+///
+/// // Read all points
+/// let points = reader.points()?;
+/// println!("Read {} points", points.len());
+/// # Ok(())
+/// # }
+/// ```
 pub struct PointCloudReader<'a> {
     reader: las::Reader<'a>,
 }

--- a/crates/pointslicer-core/src/pointcloud/writer.rs
+++ b/crates/pointslicer-core/src/pointcloud/writer.rs
@@ -3,7 +3,30 @@ use las::{Builder, Header, Point, Write};
 use std::io::BufWriter;
 use std::path::Path;
 
-/// Wrapper for writing LAS/LAZ files
+/// Wrapper for writing LAS/LAZ files with format preservation.
+///
+/// This struct provides a convenient interface for writing point cloud data
+/// to LAS or LAZ files, with automatic compression for LAZ files and
+/// preservation of the original point format.
+///
+/// # Examples
+///
+/// ```no_run
+/// use pointslicer_core::pointcloud::{PointCloudReader, PointCloudWriter};
+///
+/// # fn main() -> Result<(), pointslicer_core::TileIndexError> {
+/// // Read points from a source file
+/// let mut reader = PointCloudReader::open("source.laz")?;
+/// let points = reader.points()?;
+///
+/// // Create a new file with the same header (preserves point format)
+/// let mut writer = PointCloudWriter::create("output.laz", reader.header().clone())?;
+///
+/// // Write points
+/// writer.write_points(&points)?;
+/// # Ok(())
+/// # }
+/// ```
 pub struct PointCloudWriter<W: 'static + std::io::Write + std::io::Seek + std::fmt::Debug + Send> {
     writer: las::Writer<W>,
 }


### PR DESCRIPTION
- Add Cargo.toml metadata for both pointslicer-core and pointslicer-cli crates
  with descriptions, repository, keywords, categories, license, and documentation URLs
- Add comprehensive rustdoc to all public modules:
  - Root module with library overview and usage examples
  - Error module with detailed error variant documentation
  - Geometry module with trait-based system documentation
  - Index module with GeoPackage tile index reading documentation
  - Pipeline module with extraction workflow documentation
  - PointCloud module with LAS/LAZ I/O documentation
- Fix documentation examples to compile correctly
- All tests pass, no clippy warnings, formatting correct
